### PR TITLE
[EL-60] Fix handleEmptyAssetBondMinted emitted in a batch transaction

### DIFF
--- a/src/mappings/TokenizerMapping.ts
+++ b/src/mappings/TokenizerMapping.ts
@@ -25,9 +25,11 @@ enum AssetBondTokenState {
 }
 
 export function handleEmptyAssetBondMinted(event: EmptyAssetBondMinted): void {
-  let assetBondToken = new AssetBondToken(event.params.tokenId.toString())
-  let collateralServiceProvider = findOrCreateUser(event.params.account.toHex());
-  let tokenizer = Tokenizer.load(event.transaction.to.toHex());
+  let assetBondToken = new AssetBondToken(event.params.tokenId.toString());
+  let collateralServiceProvider = findOrCreateUser(
+    event.params.account.toHex()
+  );
+  let tokenizer = Tokenizer.load(event.address.toHex());
 
   assetBondToken.collateralServiceProvider = collateralServiceProvider.id;
   assetBondToken.state = AssetBondTokenState.EMPTY;


### PR DESCRIPTION
## Problem
https://etherscan.io/tx/0x1c331251d99743c649e330dcc3a65fa5f3bbfd3bfd1bfc8f4be985c703599961

## Reason
In a batch request, `event.transaction.to` is the multisig wallet, not the Tokenizer contract, so `Tokenizer.load(event.transaction.to.toHex())` returns `null`.

## Solution
Replace `event.transaction.to` with `event.address`, i.e. the contract address where the event is emitted.